### PR TITLE
Update composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,11 +18,11 @@
   ],
   "require": {
     "php": ">=5.5.9",
-    "illuminate/console": "~5.0",
-    "illuminate/filesystem": "~5.0",
-    "illuminate/database": "~5.0",
-    "illuminate/support": "~5.0",
-    "illuminate/config": "~5.0"
+    "illuminate/console": "5.0.* || 5.1.* || 5.2.* || 5.3.* || 5.4.* || 5.5.*",
+    "illuminate/filesystem": "5.0.* || 5.1.* || 5.2.* || 5.3.* || 5.4.* || 5.5.*",
+    "illuminate/database": "5.0.* || 5.1.* || 5.2.* || 5.3.* || 5.4.* || 5.5.*",
+    "illuminate/support": "5.0.* || 5.1.* || 5.2.* || 5.3.* || 5.4.* || 5.5.*",
+    "illuminate/config": "5.0.* || 5.1.* || 5.2.* || 5.3.* || 5.4.* || 5.5.*"
   },
   "require-dev": {
     "phpunit/phpunit": "~5.4.0",


### PR DESCRIPTION
Laravel doesn't follow semver. So having `^5.x`, `5.*` or `>=5.x` will mean that composer will install a future version even though that version breaks the package.