### PR TITLE
Injectable filter

### DIFF
--- a/src/Filterable.php
+++ b/src/Filterable.php
@@ -27,7 +27,7 @@ trait Filterable
         }
 
         // Create the model filter instance
-        $modelFilter = new $filter($query, $input);
+        $modelFilter = resolve($filter, ['query' => $query, 'input' => $input]);
 
         // Set the input that was used in the filter (this will exclude empty strings)
         $this->filtered = $modelFilter->input();

--- a/src/ModelFilter.php
+++ b/src/ModelFilter.php
@@ -306,7 +306,7 @@ abstract class ModelFilter
             $filterClass = $this->getRelatedFilter($related);
 
             // Disable querying joined relations on filters of joined tables.
-            (new $filterClass($this->query, $relatedFilterInput, false))->handle();
+            (resolve($filterClass, ['query' => $this->query, 'input' => $relatedFilterInput, 'relationsEnabled' => false]))->handle();
         }
     }
 


### PR DESCRIPTION
Instantiate filters by `resolve()` function instead of `new` operator to allow inject in filter classes.

In my case it's required to allow inject string to month number converter to filter model by month_number integer field by period filter defined by string like `2020-06`.