### PR TITLE
Array automatic null filter

### DIFF
--- a/src/ModelFilter.php
+++ b/src/ModelFilter.php
@@ -122,7 +122,11 @@ abstract class ModelFilter
         $filterableInput = [];
 
         foreach ($input as $key => $val) {
-            if ($val !== '' && $val !== null) {
+            if (is_array($val)) {
+                if (! empty($val)) {
+                    $filterableInput[$key] = $val;
+                }
+            } else if ($val !== '' && $val !== null) {
                 $filterableInput[$key] = $val;
             }
         }

--- a/src/ModelFilter.php
+++ b/src/ModelFilter.php
@@ -123,8 +123,8 @@ abstract class ModelFilter
 
         foreach ($input as $key => $val) {
             if (is_array($val)) {
-                if (! empty($val)) {
-                    $filterableInput[$key] = $val;
+                if ($arrayVal = $this->removeEmptyInput($val)) {
+                    $filterableInput[$key] = $arrayVal;
                 }
             } else if ($val !== '' && $val !== null) {
                 $filterableInput[$key] = $val;


### PR DESCRIPTION
Sometimes, we pass in an array, but there may be some null values ​​in the array, which are often passed in by some request parameters, such as：
 ```php
$array = ['times' => ['start_time' =>'', ' end_time' => '2020-08-11'],'name' =>'','sex' => 1]
```
if the start and end time in `times` are all empty, we hope the program will automatically Filter out, useless empty array