### PR TITLE
Fix PHPDoc param tag in related function

### DIFF
--- a/src/ModelFilter.php
+++ b/src/ModelFilter.php
@@ -168,8 +168,8 @@ abstract class ModelFilter
      *
      * @param $relation
      * @param $column
-     * @param null $operator
-     * @param null $value
+     * @param string|null $operator
+     * @param string|null $value
      * @param string $boolean
      * @return $this
      */


### PR DESCRIPTION
Fixed error from phpstan:

```
 Parameter #3 $operator of method EloquentFilter\ModelFilter::related() expects null, string given.
```