### PR TITLE
When generating a filter, replace the / separator with \

### DIFF
--- a/src/Commands/MakeEloquentFilter.php
+++ b/src/Commands/MakeEloquentFilter.php
@@ -56,18 +56,18 @@ class MakeEloquentFilter extends Command
     public function handle()
     {
         $this->makeClassName()->compileStub();
-        $this->info(class_basename($this->getClassName()) . ' Created Successfully!');
+        $this->info(class_basename($this->getClassName()).' Created Successfully!');
     }
 
     public function compileStub()
     {
         if ($this->files->exists($path = $this->getPath())) {
-            $this->error("\n\n\t" . $path . ' Already Exists!' . "\n");
+            $this->error("\n\n\t".$path.' Already Exists!'."\n");
             exit;
         }
         $this->makeDirectory($path);
 
-        $stubPath = config('eloquentfilter.generator.stub', __DIR__ . '/../stubs/modelfilter.stub');
+        $stubPath = config('eloquentfilter.generator.stub', __DIR__.'/../stubs/modelfilter.stub');
 
         if (! $this->files->exists($stubPath) || ! is_readable($stubPath)) {
             $this->error(sprintf('File "%s" does not exist or is unreadable.', $stubPath));
@@ -82,7 +82,7 @@ class MakeEloquentFilter extends Command
     {
         $className = $this->getClassBasename($this->getClassName());
         $search = ['{{class}}', '{{namespace}}'];
-        $replace = [$className, str_replace('\\' . $className, '', $this->getClassName())];
+        $replace = [$className, str_replace('\\'.$className, '', $this->getClassName())];
 
         return str_replace($search, $replace, $stub);
     }
@@ -96,12 +96,12 @@ class MakeEloquentFilter extends Command
 
     public function getPath()
     {
-        return $this->laravel->path . DIRECTORY_SEPARATOR . $this->getFileName();
+        return $this->laravel->path.DIRECTORY_SEPARATOR.$this->getFileName();
     }
 
     public function getFileName()
     {
-        return str_replace([$this->getAppNamespace(), '\\'], ['', DIRECTORY_SEPARATOR], $this->getClassName() . '.php');
+        return str_replace([$this->getAppNamespace(), '\\'], ['', DIRECTORY_SEPARATOR], $this->getClassName().'.php');
     }
 
     public function getAppNamespace()
@@ -131,9 +131,9 @@ class MakeEloquentFilter extends Command
     {
         $parts = array_map([Str::class, 'studly'], explode('\\', str_replace('/', '\\', $this->argument('name'))));
         $className = array_pop($parts);
-        $ns = count($parts) > 0 ? implode('\\', $parts) . '\\' : '';
+        $ns = count($parts) > 0 ? implode('\\', $parts).'\\' : '';
 
-        $fqClass = config('eloquentfilter.namespace', 'App\\ModelFilters\\') . $ns . $className;
+        $fqClass = config('eloquentfilter.namespace', 'App\\ModelFilters\\').$ns.$className;
 
         if (substr($fqClass, -6, 6) !== 'Filter') {
             $fqClass .= 'Filter';

--- a/src/Commands/MakeEloquentFilter.php
+++ b/src/Commands/MakeEloquentFilter.php
@@ -56,18 +56,18 @@ class MakeEloquentFilter extends Command
     public function handle()
     {
         $this->makeClassName()->compileStub();
-        $this->info(class_basename($this->getClassName()).' Created Successfully!');
+        $this->info(class_basename($this->getClassName()) . ' Created Successfully!');
     }
 
     public function compileStub()
     {
         if ($this->files->exists($path = $this->getPath())) {
-            $this->error("\n\n\t".$path.' Already Exists!'."\n");
+            $this->error("\n\n\t" . $path . ' Already Exists!' . "\n");
             exit;
         }
         $this->makeDirectory($path);
 
-        $stubPath = config('eloquentfilter.generator.stub', __DIR__.'/../stubs/modelfilter.stub');
+        $stubPath = config('eloquentfilter.generator.stub', __DIR__ . '/../stubs/modelfilter.stub');
 
         if (! $this->files->exists($stubPath) || ! is_readable($stubPath)) {
             $this->error(sprintf('File "%s" does not exist or is unreadable.', $stubPath));
@@ -82,7 +82,7 @@ class MakeEloquentFilter extends Command
     {
         $className = $this->getClassBasename($this->getClassName());
         $search = ['{{class}}', '{{namespace}}'];
-        $replace = [$className, str_replace('\\'.$className, '', $this->getClassName())];
+        $replace = [$className, str_replace('\\' . $className, '', $this->getClassName())];
 
         return str_replace($search, $replace, $stub);
     }
@@ -96,12 +96,12 @@ class MakeEloquentFilter extends Command
 
     public function getPath()
     {
-        return $this->laravel->path.DIRECTORY_SEPARATOR.$this->getFileName();
+        return $this->laravel->path . DIRECTORY_SEPARATOR . $this->getFileName();
     }
 
     public function getFileName()
     {
-        return str_replace([$this->getAppNamespace(), '\\'], ['', DIRECTORY_SEPARATOR], $this->getClassName().'.php');
+        return str_replace([$this->getAppNamespace(), '\\'], ['', DIRECTORY_SEPARATOR], $this->getClassName() . '.php');
     }
 
     public function getAppNamespace()
@@ -129,11 +129,11 @@ class MakeEloquentFilter extends Command
      */
     public function makeClassName()
     {
-        $parts = array_map([Str::class, 'studly'], explode('\\', $this->argument('name')));
+        $parts = array_map([Str::class, 'studly'], explode('\\', str_replace('/', '\\', $this->argument('name'))));
         $className = array_pop($parts);
-        $ns = count($parts) > 0 ? implode('\\', $parts).'\\' : '';
+        $ns = count($parts) > 0 ? implode('\\', $parts) . '\\' : '';
 
-        $fqClass = config('eloquentfilter.namespace', 'App\\ModelFilters\\').$ns.$className;
+        $fqClass = config('eloquentfilter.namespace', 'App\\ModelFilters\\') . $ns . $className;
 
         if (substr($fqClass, -6, 6) !== 'Filter') {
             $fqClass .= 'Filter';


### PR DESCRIPTION
When generating a filter, replace the / separator with \, to maintain consistency with the model and controller behavior generated by the laravel framework